### PR TITLE
Add development environment setup (AGENTS.md + pnpm build config)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+This is **hacksore.com** — a personal portfolio/blog site built with **Astro 5** (SSR mode), **React 19**, **Tailwind CSS v4**, and **Biome** for linting/formatting. Deployed to **Vercel**. Single service, no monorepo.
+
+### Key commands
+
+| Task | Command |
+|------|---------|
+| Dev server | `pnpm dev` (port 4321) |
+| Build | `pnpm build` |
+| Lint/check | `pnpm check` |
+| Format | `pnpm format` |
+| Auto-fix | `pnpm fix` |
+
+### Environment variables
+
+A `.env` file is required at the project root. Copy `.env.example` and fill in values. All env fields defined in `astro.config.ts` are required by Astro's env schema (no `optional` flag):
+
+- `DEVTO_TOKEN` — Dev.to API key (used on homepage to fetch articles; placeholder value is fine for dev, but homepage will show empty articles)
+- `R2_BUCKET_NAME`, `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_PUBLIC_URL` — Cloudflare R2 config (only the `/pics` page uses these; all other pages work with placeholder values)
+
+### Gotchas
+
+- **pnpm build scripts**: `esbuild` and `sharp` require build script execution. The `pnpm.onlyBuiltDependencies` field in `package.json` allows them. Without this, `pnpm install` will warn about ignored build scripts and binaries won't be available.
+- **Astro adapter**: The project uses `@astrojs/vercel` adapter. `pnpm dev` works locally without Vercel, but `pnpm build` produces Vercel-specific output in `dist/` and `.vercel/`.
+- **No automated test suite**: There are no unit/integration tests in this repo. Validation is done via `pnpm check` (Biome) and manual testing.

--- a/package.json
+++ b/package.json
@@ -34,5 +34,11 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.9",
     "@tailwindcss/typography": "^0.5.19"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "sharp"
+    ]
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds development environment configuration for Cursor Cloud agents and fixes a pnpm build script issue.

## Changes

- **`AGENTS.md`**: New file with Cursor Cloud specific development instructions including key commands, environment variable requirements, and gotchas
- **`package.json`**: Added `pnpm.onlyBuiltDependencies` to allow `esbuild` and `sharp` build scripts to run without interactive `pnpm approve-builds` prompts

## Dev Environment Verification

All checks pass with the development environment:

- **Lint**: `pnpm check` passes (1 pre-existing warning about unused import)
- **Build**: `pnpm build` completes successfully
- **Dev server**: `pnpm dev` starts on port 4321 with all pages returning 200

### Demo

[demo_hacksore_site_navigation.mp4](https://cursor.com/agents/bc-34beed11-b60f-46b2-82ce-e77f39b46f6a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_hacksore_site_navigation.mp4)

Site navigation across Homepage, Projects, and Cape pages working correctly.

[Homepage](https://cursor.com/agents/bc-34beed11-b60f-46b2-82ce-e77f39b46f6a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage.webp)
[Projects page](https://cursor.com/agents/bc-34beed11-b60f-46b2-82ce-e77f39b46f6a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fprojects_page.webp)
[Cape page with 3D viewer](https://cursor.com/agents/bc-34beed11-b60f-46b2-82ce-e77f39b46f6a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcape_page.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34beed11-b60f-46b2-82ce-e77f39b46f6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34beed11-b60f-46b2-82ce-e77f39b46f6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

