### PR TITLE
Add AWS organization badge to Dev.to post cards

### DIFF
--- a/src/components/post-card.tsx
+++ b/src/components/post-card.tsx
@@ -35,18 +35,8 @@ export const PostCard = ({ post }: { post: Post }) => {
       rel="noopener noreferrer"
     >
       {post.cover_image && (
-        <div className="aspect-video overflow-hidden bg-gray-900 relative">
+        <div className="aspect-video overflow-hidden bg-gray-900">
           <img src={post.cover_image} alt={post.title} className="w-full h-full object-cover" />
-          {post.organization?.slug === "aws" && (
-            <div className="absolute top-3 right-3 flex items-center gap-1.5 bg-gray-900/85 backdrop-blur-sm text-white text-xs font-semibold px-2.5 py-1.5 rounded-full border border-gray-700/50">
-              <img
-                src={post.organization.profile_image_90}
-                alt={post.organization.name}
-                className="w-4 h-4 rounded-full"
-              />
-              <span>AWS</span>
-            </div>
-          )}
         </div>
       )}
 
@@ -63,20 +53,34 @@ export const PostCard = ({ post }: { post: Post }) => {
           {post.content ? `${post.content.replace(/<[^>]*>/g, "").substring(0, 150)}...` : ""}
         </p>
 
-        {post.tags && Array.isArray(post.tags) && post.tags.length > 0 && (
-          <div className="flex flex-wrap gap-2">
-            {post.tags.slice(0, 3).map((tag) => (
-              <span key={tag} className="px-2 py-1 text-xs bg-gray-800 text-gray-300 rounded-md">
-                #{tag}
-              </span>
-            ))}
-            {post.tags.length > 3 && (
-              <span className="px-2 py-1 text-xs bg-gray-800 text-gray-300 rounded-md">
-                +{post.tags.length - 3}
-              </span>
-            )}
-          </div>
-        )}
+        <div className="flex items-center justify-between gap-2">
+          {post.tags && Array.isArray(post.tags) && post.tags.length > 0 ? (
+            <div className="flex flex-wrap gap-2">
+              {post.tags.slice(0, 3).map((tag) => (
+                <span key={tag} className="px-2 py-1 text-xs bg-gray-800 text-gray-300 rounded-md">
+                  #{tag}
+                </span>
+              ))}
+              {post.tags.length > 3 && (
+                <span className="px-2 py-1 text-xs bg-gray-800 text-gray-300 rounded-md">
+                  +{post.tags.length - 3}
+                </span>
+              )}
+            </div>
+          ) : (
+            <div />
+          )}
+          {post.organization?.slug === "aws" && (
+            <div className="flex items-center gap-1.5 bg-gray-900/85 backdrop-blur-sm text-white text-xs font-semibold px-2.5 py-1.5 rounded-full border border-gray-700/50 shrink-0">
+              <img
+                src={post.organization.profile_image_90}
+                alt={post.organization.name}
+                className="w-4 h-4 rounded-full"
+              />
+              <span>AWS</span>
+            </div>
+          )}
+        </div>
       </div>
     </a>
   );

--- a/src/components/post-card.tsx
+++ b/src/components/post-card.tsx
@@ -1,3 +1,11 @@
+export interface PostOrganization {
+  name: string;
+  username: string;
+  slug: string;
+  profile_image: string;
+  profile_image_90: string;
+}
+
 export interface Post {
   id: string;
   title: string;
@@ -7,6 +15,7 @@ export interface Post {
   published_at: string;
   reading_time_minutes?: number;
   tags?: string[];
+  organization?: PostOrganization;
 }
 
 export const PostCard = ({ post }: { post: Post }) => {
@@ -26,8 +35,18 @@ export const PostCard = ({ post }: { post: Post }) => {
       rel="noopener noreferrer"
     >
       {post.cover_image && (
-        <div className="aspect-video overflow-hidden bg-gray-900">
+        <div className="aspect-video overflow-hidden bg-gray-900 relative">
           <img src={post.cover_image} alt={post.title} className="w-full h-full object-cover" />
+          {post.organization?.slug === "aws" && (
+            <div className="absolute top-3 right-3 flex items-center gap-1.5 bg-gray-900/85 backdrop-blur-sm text-white text-xs font-semibold px-2.5 py-1.5 rounded-full border border-gray-700/50">
+              <img
+                src={post.organization.profile_image_90}
+                alt={post.organization.name}
+                className="w-4 h-4 rounded-full"
+              />
+              <span>AWS</span>
+            </div>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a small AWS badge to blog post cards on the homepage when the post was published under the AWS organization on Dev.to. This gives visitors a clear visual indicator that the article was written on behalf of AWS.

## Changes

- **`src/components/post-card.tsx`**: 
  - Added `PostOrganization` interface to type the `organization` field from the Dev.to API response
  - Added `organization` as an optional field on the `Post` interface
  - Renders an AWS badge (org icon + "AWS" text) in the bottom-right of the card body, inline with the tags row, when `organization.slug === "aws"`

## How it works

The Dev.to API already returns an `organization` object on articles posted under an org. The badge conditionally renders only when the org slug is `"aws"`, using the org's profile image from the API response. No additional API calls or config needed.

## Demo

[demo_aws_badge_bottom_right.mp4](https://cursor.com/agents/bc-34beed11-b60f-46b2-82ce-e77f39b46f6a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_aws_badge_bottom_right.mp4)

AWS badge sits in the bottom-right of the card, inline with tags.

[AWS badge in bottom-right of card](https://cursor.com/agents/bc-34beed11-b60f-46b2-82ce-e77f39b46f6a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faws_badge_bottom_right.webp)
[Grid showing badge only on AWS posts](https://cursor.com/agents/bc-34beed11-b60f-46b2-82ce-e77f39b46f6a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faws_badge_bottom_right_grid.webp)

cc @Hacksore for review


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34beed11-b60f-46b2-82ce-e77f39b46f6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34beed11-b60f-46b2-82ce-e77f39b46f6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

