### PR TITLE
Explore corepack

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,3 @@
-packages:
-  - "."
-
 allowBuilds:
   esbuild: true
   sharp: true


### PR DESCRIPTION
Current vercel build logs:

```
Running build in Washington, D.C., USA (East) – iad1
Build machine configuration: 4 cores, 8 GB
Cloning github.com/Hacksore/Hacksore (Branch: test/vercel-corepack, Commit: 261d9d3)
Cloning completed: 318.000ms
Restored build cache from previous deployment (ENhGG1mEcS2TpKgsNjfhbZe49cQu)
Running "vercel build"
Vercel CLI 54.14.0
Detected `pnpm-lock.yaml` 9 which may be generated by pnpm@9.x or pnpm@10.x
Using pnpm@9.x based on project creation date
To use pnpm@10.x, manually opt in using corepack (https://vercel.com/docs/deployments/configure-a-build#corepack)
Installing dependencies...
 ERROR  packages field missing or empty
For help, run: pnpm help install
Error: Command "pnpm install" exited with 1
```